### PR TITLE
Added ability to capture split coefficient from json

### DIFF
--- a/src/ThreeFourteen.AlphaVantage/Model/TimeSeriesAdjustedEntry.cs
+++ b/src/ThreeFourteen.AlphaVantage/Model/TimeSeriesAdjustedEntry.cs
@@ -5,5 +5,6 @@
         public double AdjustedClose { get; internal set; }
 
         public double DividendAmount { get; internal set; }
+        public double SplitCoefficient { get; internal set; }
     }
 }

--- a/src/ThreeFourteen.AlphaVantage/Response/JsonExtensions.cs
+++ b/src/ThreeFourteen.AlphaVantage/Response/JsonExtensions.cs
@@ -33,7 +33,8 @@ namespace ThreeFourteen.AlphaVantage.Response
                 Close = token.First.Value<double>("4. close"),
                 AdjustedClose = token.First.Value<double>("5. adjusted close"),
                 Volume = token.First.Value<long>("6. volume"),
-                DividendAmount = token.First.Value<double>("7. dividend amount")
+                DividendAmount = token.First.Value<double>("7. dividend amount"),
+                SplitCoefficient = token.First.Value<double>("8. split coefficient")
             };
 
             return entry;

--- a/test/ThreeFourteen.AlphaVantage.Test/Builders/Stocks/StockDailyAdjustedBuilderTests.cs
+++ b/test/ThreeFourteen.AlphaVantage.Test/Builders/Stocks/StockDailyAdjustedBuilderTests.cs
@@ -32,6 +32,7 @@ namespace ThreeFourteen.AlphaVantage.Test.Builders.Stocks
             first.AdjustedClose.ShouldBe(106.8700);
             first.Volume.ShouldBe(17326964);
             first.DividendAmount.ShouldBe(0.0000);
+            first.SplitCoefficient.ShouldBe(1.0);
             var last = timeseries.Data.Last();
             last.Timestamp.ShouldBe(Formats.ParseDateTime("2018-03-29"));
             last.Open.ShouldBe(90.1800);
@@ -41,6 +42,7 @@ namespace ThreeFourteen.AlphaVantage.Test.Builders.Stocks
             last.AdjustedClose.ShouldBe(90.5240);
             last.Volume.ShouldBe(45867548);
             last.DividendAmount.ShouldBe(0.0000);
+            last.SplitCoefficient.ShouldBe(1.0);
         }
     }
 }

--- a/test/ThreeFourteen.AlphaVantage.Test/Builders/Stocks/StockMonthlyAdjustedBuilderTests.cs
+++ b/test/ThreeFourteen.AlphaVantage.Test/Builders/Stocks/StockMonthlyAdjustedBuilderTests.cs
@@ -31,6 +31,7 @@ namespace ThreeFourteen.AlphaVantage.Test.Builders.Stocks
             first.AdjustedClose.ShouldBe(106.8700);
             first.Volume.ShouldBe(274693160);
             first.DividendAmount.ShouldBe(0.4200);
+            first.SplitCoefficient.ShouldBe(0.0);
             var last = timeseries.Data.Last();
             last.Timestamp.ShouldBe(Formats.ParseDateTime("1995-02-28"));
             last.Open.ShouldBe(59.3800);
@@ -40,6 +41,7 @@ namespace ThreeFourteen.AlphaVantage.Test.Builders.Stocks
             last.AdjustedClose.ShouldBe(2.5878);
             last.Volume.ShouldBe(62416100);
             last.DividendAmount.ShouldBe(0.0000);
+            last.SplitCoefficient.ShouldBe(0.0);
         }
     }
 }

--- a/test/ThreeFourteen.AlphaVantage.Test/Builders/Stocks/StockWeeklyAdjustedBuilderTests.cs
+++ b/test/ThreeFourteen.AlphaVantage.Test/Builders/Stocks/StockWeeklyAdjustedBuilderTests.cs
@@ -31,6 +31,7 @@ namespace ThreeFourteen.AlphaVantage.Test.Builders.Stocks
             first.AdjustedClose.ShouldBe(107.6400);
             first.Volume.ShouldBe(85933126);
             first.DividendAmount.ShouldBe(0.4200);
+            first.SplitCoefficient.ShouldBe(0.0);
             var last = timeseries.Data.Last();
             last.Timestamp.ShouldBe(Formats.ParseDateTime("1995-01-13"));
             last.Open.ShouldBe(60.8800);
@@ -40,6 +41,7 @@ namespace ThreeFourteen.AlphaVantage.Test.Builders.Stocks
             last.AdjustedClose.ShouldBe(2.5775);
             last.Volume.ShouldBe(11750000);
             last.DividendAmount.ShouldBe(0.0000);
+            last.SplitCoefficient.ShouldBe(0.0);
         }
     }
 }


### PR DESCRIPTION
When pulling stock data for daily time series adjusted, the split coefficient was not being captured by any models.  I've added the field.  it is ignored when its a monthly or weekly time series adjusted and defaults to 0.  I've tested using existing tests and added new assertions in those scenarios just mentioned.  

Without the split coefficient, we cannot tell when and how the stock was split.

By the way, this is a nice library you have created!  I like your design  👍 