### PR TITLE
Added a base class for entries

### DIFF
--- a/src/ThreeFourteen.AlphaVantage/Model/CryptoEntry.cs
+++ b/src/ThreeFourteen.AlphaVantage/Model/CryptoEntry.cs
@@ -2,13 +2,8 @@
 
 namespace ThreeFourteen.AlphaVantage.Model
 {
-    public class CryptoEntry
+    public class CryptoEntry : Entry
     {
-        public DateTime Timestamp { get; internal set; }
-        public double Open { get; internal set; }
-        public double High { get; internal set; }
-        public double Low { get; internal set; }
-        public double Close { get; internal set; }
         public double OpenUsd { get; internal set; }
         public double HighUsd { get; internal set; }
         public double LowUsd { get; internal set; }

--- a/src/ThreeFourteen.AlphaVantage/Model/Entry.cs
+++ b/src/ThreeFourteen.AlphaVantage/Model/Entry.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace ThreeFourteen.AlphaVantage.Model
+{
+    public class Entry
+    {
+        public DateTime Timestamp { get; internal set; }
+
+        public double Open { get; internal set; }
+
+        public double High { get; internal set; }
+
+        public double Low { get; internal set; }
+
+        public double Close { get; internal set; }
+    }
+}

--- a/src/ThreeFourteen.AlphaVantage/Model/FxEntry.cs
+++ b/src/ThreeFourteen.AlphaVantage/Model/FxEntry.cs
@@ -1,17 +1,6 @@
 ﻿using System;
 
 namespace ThreeFourteen.AlphaVantage.Model
-{
-    public class FxEntry
-    {
-        public DateTime Timestamp { get; internal set; }
-
-        public double Open { get; internal set; }
-
-        public double High { get; internal set; }
-
-        public double Low { get; internal set; }
-
-        public double Close { get; internal set; }
-    }
+{ //This class has been kept to maintain compatibility.
+    public class FxEntry : Entry { }
 }

--- a/src/ThreeFourteen.AlphaVantage/Model/TimeSeriesEntry.cs
+++ b/src/ThreeFourteen.AlphaVantage/Model/TimeSeriesEntry.cs
@@ -2,18 +2,8 @@
 
 namespace ThreeFourteen.AlphaVantage.Model
 {
-    public class TimeSeriesEntry
+    public class TimeSeriesEntry : Entry
     {
-        public DateTime Timestamp { get; internal set; }
-
-        public double Open { get; internal set; }
-
-        public double High { get; internal set; }
-
-        public double Low { get; internal set; }
-
-        public double Close { get; internal set; }
-
         public long Volume { get; internal set; }
     }
 }


### PR DESCRIPTION
I added a class that all forms entries inherit from to collect the generic data.  This is very useful if, for example, you want to have a variable that could hold any type of entry.

I did not delete fxEntry and just use because I was aware it may need to be extended with some unique data at some point if the API changes.